### PR TITLE
Add default backend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To use the kitty backend for matplotlib:
 ```python
 %plt_icat
 ```
+After running this command, any matplotlib plots you create will be displayed directly in your kitty terminal.
 
 ### Use as a Default Backend
 
@@ -42,8 +43,6 @@ To set the kitty backend for matplotlib as the default, add the following lines 
 
 1. `c.InteractiveShellApp.extensions = ['icat']`
 2. `c.InteractiveShellApp.exec_lines = ['%plt_icat']`
-
-After running this command, any matplotlib plots you create will be displayed directly in your kitty terminal.
 
 ### Displaying Images
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ To use the kitty backend for matplotlib:
 %plt_icat
 ```
 
+### Use as a Default Backend
+
+To set the kitty backend for matplotlib as the default, add the following lines to your IPython configuration file:
+
+1. `c.InteractiveShellApp.extensions = ['icat']`
+2. `c.InteractiveShellApp.exec_lines = ['%plt_icat']`
+
 After running this command, any matplotlib plots you create will be displayed directly in your kitty terminal.
 
 ### Displaying Images


### PR DESCRIPTION
Include steps to set kitty as the default backend for matplotlib in IPython.

@Kabilan108 please consider to add this, will be useful to many others. btw, great idea and powerful addition, thank u.