### PR TITLE
Add setup script for IPython profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ To set the kitty backend for matplotlib as the default, add the following lines 
 1. `c.InteractiveShellApp.extensions = ['icat']`
 2. `c.InteractiveShellApp.exec_lines = ['%plt_icat']`
 
+#### Instant Initialization
+
+To quickly start working on a remote machine, use the `pycat setup` command after installing the package.
+This command creates a default IPython profile with the above configuration.
+This feature is useful for quick setup of environment.
+
 ### Displaying Images
 
 To display an image file or a PIL Image object:

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -15,6 +15,11 @@ from matplotlib._pylab_helpers import Gcf
 import matplotlib
 
 from PIL import Image
+from . import utils
+
+
+PACKAGE_NAME = "pycat"
+
 
 if hasattr(sys, "ps1") or sys.flags.interactive:
     interactive(True)
@@ -113,3 +118,28 @@ def icat(img: Image.Image, width: int = None, height: int = None):
 
 def load_ipython_extension(ipython):
     ipython.register_magics(ICatMagics)
+
+
+def setup_ipython_profile(ipython_path=None, profile_name="default"):
+    """Update or create an IPython profile to use the icat backend."""
+
+    profile_path = utils.get_profile_path(ipython_path, profile_name)
+    extensions_line, exec_lines_line = utils.dynamic_update_config(
+        profile_path, os.path.dirname(profile_path)
+    )
+    lines = utils.dynamic_update_file(profile_path, extensions_line, exec_lines_line)
+    with open(profile_path, "w") as f:
+        f.writelines(lines)
+
+
+def main():
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "setup":
+        setup_ipython_profile()
+    else:
+        print(f"Usage: {PACKAGE_NAME} setup")
+
+
+if __name__ == "__main__":
+    main()

--- a/icat/utils.py
+++ b/icat/utils.py
@@ -1,0 +1,69 @@
+import os
+import subprocess
+from traitlets.config import Config
+from traitlets.config.loader import PyFileConfigLoader
+
+
+def get_profile_path(ipython_path, profile_name):
+    """Silently create a default profile if it doesn't exist"""
+    if ipython_path is None:
+        ipython_path = os.path.expanduser("~/.ipython")
+    profile_dir = os.path.join(ipython_path, f"profile_{profile_name}")
+    if not os.path.exists(profile_dir):
+        subprocess.run(["ipython", "profile", "create", profile_name])
+    profile_path = os.path.join(profile_dir, "ipython_config.py")
+    return profile_path
+
+
+def dynamic_update_config(profile_path, profile_dir):
+    """Returns updated extensions and exec_lines"""
+    # Create Config object and load existing configuration if available
+    config = Config()
+    if os.path.exists(profile_path):
+        config_loader = PyFileConfigLoader(
+            filename="ipython_config.py", path=profile_dir
+        )
+        config = config_loader.load_config()
+
+    # Ensure extensions and exec_lines are lists
+    extensions = config.get("InteractiveShellApp", {}).get("extensions", [])
+    exec_lines = config.get("InteractiveShellApp", {}).get("exec_lines", [])
+
+    if "icat" not in extensions:
+        extensions.append("icat")
+
+    if "%plt_icat" not in exec_lines:
+        exec_lines.append("%plt_icat")
+
+    extensions_line = f"c.InteractiveShellApp.extensions = {extensions}\n"
+    exec_lines_line = f"c.InteractiveShellApp.exec_lines = {exec_lines}\n"
+
+    return extensions_line, exec_lines_line
+
+
+def dynamic_update_file(profile_path, extensions_line, exec_lines_line):
+    # Read and modify only the necessary lines
+    if os.path.exists(profile_path):
+        with open(profile_path, "r") as f:
+            lines = f.readlines()
+
+        # Modify lines if they exist; otherwise, add them
+        found_extensions = False
+        found_exec_lines = False
+
+        for i, line in enumerate(lines):
+            if line.startswith("c.InteractiveShellApp.extensions ="):
+                lines[i] = extensions_line
+                found_extensions = True
+            elif line.startswith("c.InteractiveShellApp.exec_lines ="):
+                lines[i] = exec_lines_line
+                found_exec_lines = True
+
+        if not found_extensions:
+            lines.append(extensions_line)
+        if not found_exec_lines:
+            lines.append(exec_lines_line)
+
+        return lines
+    else:
+        return [extensions_line, exec_lines_line]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,5 @@ dev-dependencies = [
 ]
 package = true
 
+[project.scripts]
+pycat = "icat.__init__:main"


### PR DESCRIPTION
Implemented setup script to configure IPython profile for icat usage.

It can support custom ipython profiles but currently it happens just for the default profile.

The reasons I did not do it for general profile:
1. it is not too important to begin with. the core usage IMO is logging to some new remote machine and instantly setting up everything to work.
2. it will be better to support arguments when there is a consistent way of handling arguments for other commands if there are any

so in short, i don't think it's relevant to support any profile at this moment