### PR TITLE
Fix: Avoid raising an error if user does not provide profile dir

### DIFF
--- a/icat/__main__.py
+++ b/icat/__main__.py
@@ -80,7 +80,7 @@ def get_profile_path(profile_name: str, ipython_path: Optional[str] = None) -> P
             ipython_path = Path.home() / ".ipython"
         else:
             ipython_path = Path(ipython_path).expanduser().resolve()
-            if not ipython_path.exist():
+            if not ipython_path.exists():
                 # Since ipython_path parameter is not None, it must be a valid path
                 raise FileNotFoundError(f"IPython path {ipython_path} does not exist")
 

--- a/icat/__main__.py
+++ b/icat/__main__.py
@@ -82,7 +82,13 @@ def get_profile_path(profile_name: str, ipython_path: Optional[str] = None) -> P
             ipython_path = Path(ipython_path).expanduser().resolve()
 
         if not ipython_path.exists():
-            raise FileNotFoundError(f"IPython path {ipython_path} does not exist")
+            if ipython_path is not None:
+                # Since ipython_path is not None, it must be a valid path
+                raise FileNotFoundError(f"IPython path {ipython_path} does not exist")
+            else:
+                # Create a default .ipython directory
+                # ipython_path = Path.home() / ".ipython"
+                ipython_path.mkdir(parents=True)
 
         profile_dir = ipython_path / f"profile_{profile_name}"
         if not profile_dir.exists():

--- a/icat/__main__.py
+++ b/icat/__main__.py
@@ -80,15 +80,9 @@ def get_profile_path(profile_name: str, ipython_path: Optional[str] = None) -> P
             ipython_path = Path.home() / ".ipython"
         else:
             ipython_path = Path(ipython_path).expanduser().resolve()
-
-        if not ipython_path.exists():
-            if ipython_path is not None:
-                # Since ipython_path is not None, it must be a valid path
+            if not ipython_path.exist():
+                # Since ipython_path parameter is not None, it must be a valid path
                 raise FileNotFoundError(f"IPython path {ipython_path} does not exist")
-            else:
-                # Create a default .ipython directory
-                # ipython_path = Path.home() / ".ipython"
-                ipython_path.mkdir(parents=True)
 
         profile_dir = ipython_path / f"profile_{profile_name}"
         if not profile_dir.exists():


### PR DESCRIPTION
No need for command failure in case of none existing default ipython profile directory. on this case ipython will create it on the ipython profile create command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling and validation of custom IPython paths, ensuring checks are only performed when a custom path is provided.

- **Documentation**
  - Added a clarifying comment regarding the conditions under which the IPython path is validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->