### PR TITLE
Option to auto-fit images to terminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,20 @@ ipython
 # Enable icat integration (matplotlib + PIL auto-render)
 %icat
 
+# Enable icat with auto-fit to terminal size
+%icat --fit
+
 # Display an image
 %icat path/to/image.jpg
 
+# Display with auto-fit to terminal
+%icat path/to/image.jpg --fit
+
 # Display with specific dimensions
 %icat path/to/image.jpg -W 300 -H 200
+
+# Check status (shows enabled, fit, and backend info)
+%icat status
 ```
 
 ### Building & Publishing
@@ -67,3 +76,4 @@ Key features:
 - Display matplotlib plots using a custom backend
 - Show image files or PIL Image objects directly in the terminal
 - Resize images on display
+- Auto-fit images to terminal size with `--fit` flag or `IPYTHON_ICAT_FIT=1` environment variable

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ Example with custom profile:
 python -m icat setup --profile myprofile
 ```
 
+### Environment Variables
+
+The extension supports the following environment variables:
+
+- `IPYTHON_ICAT_AUTO`: Automatically enable icat integration when IPython starts. Set to `1`, `true`, `yes`, or `on` to enable.
+- `IPYTHON_ICAT_FIT`: Automatically fit all images and plots to terminal size. Set to `1`, `true`, `yes`, or `on` to enable.
+
+Example:
+```bash
+export IPYTHON_ICAT_AUTO=1
+export IPYTHON_ICAT_FIT=1
+ipython
+```
+
+
 ### Displaying Images
 
 To display an image file, a PIL Image object, or a Python expression that evaluates to a PIL Image:
@@ -101,6 +116,22 @@ You can also resize the image when displaying:
 %icat path/to/your/image.jpg -W 300 -H 200
 ```
 
+#### Auto-fit to Terminal
+
+To automatically fit an image to your terminal size while preserving its aspect ratio:
+
+```python
+%icat path/to/your/image.jpg --fit
+```
+
+You can also enable auto-fit by default using an environment variable:
+
+```bash
+export IPYTHON_ICAT_FIT=1
+```
+
+With this environment variable set, all images and matplotlib plots will automatically fit to your terminal size. You can still override this behavior by explicitly specifying width and height with `-W` and `-H` options.
+
 ### Using Ghostty
 
 If you'd like to use this plugin with Ghostty, make sure to install the [static kitten binary](https://github.com/kovidgoyal/kitty/releases) which will allow you to run `kitten icat`.
@@ -110,6 +141,7 @@ If you'd like to use this plugin with Ghostty, make sure to install the [static 
 - Display matplotlib plots directly in kitty terminal
 - Show PIL Image objects or image files
 - Resize images on display
+- Auto-fit images to terminal size
 - Seamless integration with IPython workflow
 
 ## Contributing

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -52,7 +52,7 @@ def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
         img_height: Original image height in pixels
         
     Returns:
-        Tuple of (width, height) in pixels that fit the terminal
+        Tuple of (width, height) in character cells that fit the terminal
     """
     try:
         term_size = shutil.get_terminal_size()
@@ -66,28 +66,33 @@ def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
     max_rows = max(term_rows - 2, 1)
     max_cols = max(term_cols - 2, 1)
     
-    # Typical terminal cell aspect ratio is ~1:2 (width:height in character units)
-    # but each character cell is approximately 10x20 pixels
-    # For kitty, we use character dimensions and let kitty handle the pixel conversion
-    
-    # Calculate aspect ratios
+    # Calculate aspect ratio of the image
     img_aspect = img_width / img_height if img_height > 0 else 1.0
     
-    # Character cells are roughly twice as tall as wide, so adjust
-    # We want to preserve the image aspect ratio in screen space
-    cell_aspect_ratio = 0.5  # width/height of a single character cell
+    # Terminal character cells are typically twice as tall as they are wide
+    # So to preserve image aspect ratio, we need to account for this:
+    # If image is W x H pixels, and we want it to look right in terminal,
+    # we need (cols / 2) / rows = W / H
+    # Therefore: cols = 2 * rows * (W / H)
+    # And: rows = cols / (2 * (W / H))
     
-    # Calculate the maximum dimensions that fit, preserving aspect ratio
-    # If we use max_cols columns, how many rows do we need?
-    rows_for_max_cols = max_cols / (img_aspect * cell_aspect_ratio)
+    # Try fitting by width first
+    rows_if_full_width = max_cols / (2 * img_aspect)
     
-    if rows_for_max_cols <= max_rows:
+    if rows_if_full_width <= max_rows:
         # Image fits when using full width
-        return max_cols, int(rows_for_max_cols)
+        return max_cols, max(1, int(rows_if_full_width))
     else:
-        # Need to constrain by height
-        cols_for_max_rows = int(max_rows * img_aspect * cell_aspect_ratio)
-        return cols_for_max_rows, max_rows
+        # Image is too tall, constrain by height
+        cols_if_full_height = 2 * max_rows * img_aspect
+        
+        if cols_if_full_height <= max_cols:
+            # Fits within column constraint
+            return max(1, int(cols_if_full_height)), max_rows
+        else:
+            # Still too wide even at max height, just use max dimensions
+            # This shouldn't normally happen with reasonable images
+            return max_cols, max_rows
 
 
 class FigureManagerICat(FigureManagerBase):

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -99,19 +99,20 @@ class FigureManagerICat(FigureManagerBase):
     def show(self):
         with BytesIO() as buf:
             self.canvas.figure.savefig(buf, format="png")
-            buf.seek(0)
             
             # Check if fit is enabled via environment variable
             fit_enabled = getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
             
             if fit_enabled:
                 # Get image dimensions
+                buf.seek(0)
                 img = Image.open(buf)
                 img_width, img_height = img.size
+                img.close()  # Close to release buffer
                 buf.seek(0)
-                _icat(output=False, input=buf.getbuffer(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
+                _icat(output=False, input=buf.getvalue(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
             else:
-                _icat(output=False, input=buf.getbuffer())
+                _icat(output=False, input=buf.getvalue())
 
 
 class FigureCanvasICat(FigureCanvasAgg):
@@ -186,14 +187,13 @@ class ICatMagics(Magics):
         # display image
         with BytesIO() as buf:
             img.save(buf, format="PNG")
-            buf.seek(0)
             
             if fit_enabled and not (args.width or args.height):
                 # Only apply fit if manual dimensions aren't specified
                 img_width, img_height = img.size
-                _icat(output=False, input=buf.getbuffer(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
+                _icat(output=False, input=buf.getvalue(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
             else:
-                _icat(output=False, input=buf.getbuffer())
+                _icat(output=False, input=buf.getvalue())
 
 
 def icat(img: Image.Image, width: Optional[int] = None, height: Optional[int] = None, fit: bool = False):
@@ -214,14 +214,13 @@ def icat(img: Image.Image, width: Optional[int] = None, height: Optional[int] = 
         if width or height:
             img_.thumbnail((width or img.width, height or img.height))
         img_.save(buf, format="PNG")
-        buf.seek(0)
         
         if fit_enabled and not (width or height):
             # Only apply fit if manual dimensions aren't specified
             img_width, img_height = img_.size
-            _icat(output=False, input=buf.getbuffer(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
+            _icat(output=False, input=buf.getvalue(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
         else:
-            _icat(output=False, input=buf.getbuffer())
+            _icat(output=False, input=buf.getvalue())
 
 
 def load_ipython_extension(ipython):

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -87,13 +87,14 @@ class ICatMagics(Magics):
     @argument("-W", "--width", type=int, help="Width to resize the image")
     @argument("-H", "--height", type=int, help="Height to resize the image")
     @argument("-f", "--fit", action="store_true", help="Fit image to terminal size")
+    @argument("--no-fit", action="store_true", help="Disable auto-fit for the session")
     @line_magic
     def icat(self, line):
         args = parse_argstring(self.icat, line)
         target = (args.target or "").strip()
 
         if target in {"", "on"}:
-            _enable_session(self.shell, fit=args.fit)
+            _enable_session(self.shell, fit=args.fit, no_fit=args.no_fit)
             return
         if target == "off":
             _disable_session(self.shell)
@@ -187,11 +188,14 @@ def _is_fit_enabled() -> bool:
     return False
 
 
-def _enable_session(shell, fit: bool = False) -> None:
+def _enable_session(shell, fit: bool = False, no_fit: bool = False) -> None:
     state = _session_state(shell)
     if state.get("enabled"):
-        # If already enabled, just update fit setting if requested
-        if fit:
+        # If already enabled, update fit setting based on flags
+        if no_fit:
+            state["fit"] = False
+            print("icat: auto-fit disabled for all images")
+        elif fit:
             state["fit"] = True
             print("icat: auto-fit enabled for all images")
         return
@@ -201,12 +205,12 @@ def _enable_session(shell, fit: bool = False) -> None:
     except Exception:
         state["prev_mpl_backend"] = None
 
-    # Store fit setting in session state
-    state["fit"] = fit
+    # Store fit setting in session state (--no-fit takes precedence to disable)
+    state["fit"] = fit and not no_fit
 
     try:
         matplotlib.use("module://icat")
-        fit_msg = " (with auto-fit)" if fit else ""
+        fit_msg = " (with auto-fit)" if state["fit"] else ""
         print(f"icat: enabled matplotlib backend + PIL auto-render{fit_msg}")
     except Exception as e:
         print(f"icat: failed to enable matplotlib backend: {e}")

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -87,14 +87,13 @@ class ICatMagics(Magics):
     @argument("-W", "--width", type=int, help="Width to resize the image")
     @argument("-H", "--height", type=int, help="Height to resize the image")
     @argument("-f", "--fit", action="store_true", help="Fit image to terminal size")
-    @argument("--no-fit", action="store_true", help="Disable auto-fit for the session")
     @line_magic
     def icat(self, line):
         args = parse_argstring(self.icat, line)
         target = (args.target or "").strip()
 
         if target in {"", "on"}:
-            _enable_session(self.shell, fit=args.fit, no_fit=args.no_fit)
+            _enable_session(self.shell, fit=args.fit)
             return
         if target == "off":
             _disable_session(self.shell)
@@ -188,14 +187,11 @@ def _is_fit_enabled() -> bool:
     return False
 
 
-def _enable_session(shell, fit: bool = False, no_fit: bool = False) -> None:
+def _enable_session(shell, fit: bool = False) -> None:
     state = _session_state(shell)
     if state.get("enabled"):
-        # If already enabled, update fit setting based on flags
-        if no_fit:
-            state["fit"] = False
-            print("icat: auto-fit disabled for all images")
-        elif fit:
+        # If already enabled, just update fit setting if requested
+        if fit:
             state["fit"] = True
             print("icat: auto-fit enabled for all images")
         return
@@ -205,12 +201,12 @@ def _enable_session(shell, fit: bool = False, no_fit: bool = False) -> None:
     except Exception:
         state["prev_mpl_backend"] = None
 
-    # Store fit setting in session state (--no-fit takes precedence to disable)
-    state["fit"] = fit and not no_fit
+    # Store fit setting in session state
+    state["fit"] = fit
 
     try:
         matplotlib.use("module://icat")
-        fit_msg = " (with auto-fit)" if state["fit"] else ""
+        fit_msg = " (with auto-fit)" if fit else ""
         print(f"icat: enabled matplotlib backend + PIL auto-render{fit_msg}")
     except Exception as e:
         print(f"icat: failed to enable matplotlib backend: {e}")

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 from io import BytesIO
 from os import getenv
@@ -20,11 +21,20 @@ if hasattr(sys, "ps1") or sys.flags.interactive:
 
 
 def _run(*cmd):
-    def f(*args, output=True, **kwargs):
+    def f(*args, output=True, fit_to_terminal=False, img_width=None, img_height=None, **kwargs):
+        # Build command with optional fit parameters
+        cmd_args = list(args)
+        
+        if fit_to_terminal and img_width and img_height:
+            # Calculate terminal-fit dimensions
+            fit_width, fit_height = _get_fit_dimensions(img_width, img_height)
+            # Use --place to specify cell dimensions for kitty
+            cmd_args = [f"--place={fit_width}x{fit_height}@0x0"] + cmd_args
+        
         if output:
             kwargs["capture_output"] = True
             kwargs["text"] = True
-        r = run(cmd + args, **kwargs)
+        r = run(cmd + tuple(cmd_args), **kwargs)
         if output:
             return r.stdout.rstrip()
 
@@ -34,11 +44,69 @@ def _run(*cmd):
 _icat = _run("kitten", "icat", "--align", "left")
 
 
+def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
+    """Calculate dimensions to fit image maximally in terminal.
+    
+    Args:
+        img_width: Original image width in pixels
+        img_height: Original image height in pixels
+        
+    Returns:
+        Tuple of (width, height) in pixels that fit the terminal
+    """
+    try:
+        term_size = shutil.get_terminal_size()
+        term_cols = term_size.columns
+        term_rows = term_size.lines
+    except Exception:
+        # Fallback to a reasonable default if terminal size can't be determined
+        term_cols, term_rows = 80, 24
+    
+    # Leave margin for prompt and output (2 rows for prompt, 2 cols for spacing)
+    max_rows = max(term_rows - 2, 1)
+    max_cols = max(term_cols - 2, 1)
+    
+    # Typical terminal cell aspect ratio is ~1:2 (width:height in character units)
+    # but each character cell is approximately 10x20 pixels
+    # For kitty, we use character dimensions and let kitty handle the pixel conversion
+    
+    # Calculate aspect ratios
+    img_aspect = img_width / img_height if img_height > 0 else 1.0
+    
+    # Character cells are roughly twice as tall as wide, so adjust
+    # We want to preserve the image aspect ratio in screen space
+    cell_aspect_ratio = 0.5  # width/height of a single character cell
+    
+    # Calculate the maximum dimensions that fit, preserving aspect ratio
+    # If we use max_cols columns, how many rows do we need?
+    rows_for_max_cols = max_cols / (img_aspect * cell_aspect_ratio)
+    
+    if rows_for_max_cols <= max_rows:
+        # Image fits when using full width
+        return max_cols, int(rows_for_max_cols)
+    else:
+        # Need to constrain by height
+        cols_for_max_rows = int(max_rows * img_aspect * cell_aspect_ratio)
+        return cols_for_max_rows, max_rows
+
+
 class FigureManagerICat(FigureManagerBase):
     def show(self):
         with BytesIO() as buf:
             self.canvas.figure.savefig(buf, format="png")
-            _icat(output=False, input=buf.getbuffer())
+            buf.seek(0)
+            
+            # Check if fit is enabled via environment variable
+            fit_enabled = getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
+            
+            if fit_enabled:
+                # Get image dimensions
+                img = Image.open(buf)
+                img_width, img_height = img.size
+                buf.seek(0)
+                _icat(output=False, input=buf.getbuffer(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
+            else:
+                _icat(output=False, input=buf.getbuffer())
 
 
 class FigureCanvasICat(FigureCanvasAgg):
@@ -73,6 +141,7 @@ class ICatMagics(Magics):
     )
     @argument("-W", "--width", type=int, help="Width to resize the image")
     @argument("-H", "--height", type=int, help="Height to resize the image")
+    @argument("-f", "--fit", action="store_true", help="Fit image to terminal size")
     @line_magic
     def icat(self, line):
         args = parse_argstring(self.icat, line)
@@ -102,6 +171,9 @@ class ICatMagics(Magics):
             )
             return
 
+        # Check if fit is requested via flag or environment variable
+        fit_enabled = args.fit or getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
+
         # resize the image if width or height is specified
         if args.width or args.height:
             img.thumbnail((args.width or img.width, args.height or img.height))
@@ -109,16 +181,42 @@ class ICatMagics(Magics):
         # display image
         with BytesIO() as buf:
             img.save(buf, format="PNG")
-            _icat(output=False, input=buf.getbuffer())
+            buf.seek(0)
+            
+            if fit_enabled and not (args.width or args.height):
+                # Only apply fit if manual dimensions aren't specified
+                img_width, img_height = img.size
+                _icat(output=False, input=buf.getbuffer(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
+            else:
+                _icat(output=False, input=buf.getbuffer())
 
 
-def icat(img: Image.Image, width: Optional[int] = None, height: Optional[int] = None):
+def icat(img: Image.Image, width: Optional[int] = None, height: Optional[int] = None, fit: bool = False):
+    """Display a PIL Image in the terminal.
+    
+    Args:
+        img: PIL Image to display
+        width: Optional width to resize to
+        height: Optional height to resize to
+        fit: If True, fit image to terminal size (ignored if width/height specified)
+    """
     img_ = img.copy()
+    
+    # Check if fit is requested via parameter or environment variable
+    fit_enabled = fit or getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
+    
     with BytesIO() as buf:
         if width or height:
             img_.thumbnail((width or img.width, height or img.height))
         img_.save(buf, format="PNG")
-        _icat(output=False, input=buf.getbuffer())
+        buf.seek(0)
+        
+        if fit_enabled and not (width or height):
+            # Only apply fit if manual dimensions aren't specified
+            img_width, img_height = img_.size
+            _icat(output=False, input=buf.getbuffer(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
+        else:
+            _icat(output=False, input=buf.getbuffer())
 
 
 def load_ipython_extension(ipython):

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -87,13 +87,19 @@ class ICatMagics(Magics):
     @argument("-W", "--width", type=int, help="Width to resize the image")
     @argument("-H", "--height", type=int, help="Height to resize the image")
     @argument("-f", "--fit", action="store_true", help="Fit image to terminal size")
+    @argument("--no-fit", action="store_true", help="Disable auto-fit for session")
     @line_magic
     def icat(self, line):
         args = parse_argstring(self.icat, line)
         target = (args.target or "").strip()
 
+        if args.fit and args.no_fit:
+            print("Error: --fit and --no-fit cannot be used together.")
+            return
+
         if target in {"", "on"}:
-            _enable_session(self.shell, fit=args.fit)
+            fit_pref = True if args.fit else False if args.no_fit else None
+            _enable_session(self.shell, fit=fit_pref)
             return
         if target == "off":
             _disable_session(self.shell)
@@ -187,13 +193,13 @@ def _is_fit_enabled() -> bool:
     return False
 
 
-def _enable_session(shell, fit: bool = False) -> None:
+def _enable_session(shell, fit: Optional[bool] = None) -> None:
     state = _session_state(shell)
     if state.get("enabled"):
         # If already enabled, just update fit setting if requested
-        if fit:
-            state["fit"] = True
-            print("icat: auto-fit enabled for all images")
+        if fit is not None:
+            state["fit"] = fit
+            print(f"icat: auto-fit {'enabled' if fit else 'disabled'} for all images")
         return
 
     try:
@@ -202,11 +208,11 @@ def _enable_session(shell, fit: bool = False) -> None:
         state["prev_mpl_backend"] = None
 
     # Store fit setting in session state
-    state["fit"] = fit
+    state["fit"] = bool(fit)
 
     try:
         matplotlib.use("module://icat")
-        fit_msg = " (with auto-fit)" if fit else ""
+        fit_msg = " (with auto-fit)" if state["fit"] else ""
         print(f"icat: enabled matplotlib backend + PIL auto-render{fit_msg}")
     except Exception as e:
         print(f"icat: failed to enable matplotlib backend: {e}")
@@ -249,7 +255,7 @@ def _print_status(shell) -> None:
         current = matplotlib.get_backend()
     except Exception:
         pass
-    fit = bool(state.get("fit"))
+    fit = _is_fit_enabled()
     print(
         f"icat: enabled={enabled}, fit={fit}, matplotlib_backend={current!r}, prev_backend={prev!r}"
     )

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 from io import BytesIO
 from os import getenv
@@ -21,15 +20,15 @@ if hasattr(sys, "ps1") or sys.flags.interactive:
 
 
 def _run(*cmd):
-    def f(*args, output=True, fit_to_terminal=False, img_width=None, img_height=None, **kwargs):
+    def f(*args, output=True, fit_to_terminal=False, **kwargs):
         # Build command with optional fit parameters
         cmd_args = list(args)
         
-        if fit_to_terminal and img_width is not None and img_height is not None:
-            # Calculate terminal-fit dimensions
-            fit_width, fit_height = _get_fit_dimensions(img_width, img_height)
-            # Use --place to specify cell dimensions for kitty
-            cmd_args = [f"--place={fit_width}x{fit_height}@0x0"] + cmd_args
+        if fit_to_terminal:
+            # Use kitten icat's native fit features:
+            # --scale-up: Scale up small images to fill the available area
+            # --fit both: Fit to both width and height of the terminal
+            cmd_args = ["--scale-up", "--fit", "both"] + cmd_args
         
         if output:
             kwargs["capture_output"] = True
@@ -44,64 +43,6 @@ def _run(*cmd):
 _icat = _run("kitten", "icat", "--align", "left")
 
 
-def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
-    """Calculate dimensions to fit image maximally in terminal.
-    
-    Args:
-        img_width: Original image width in pixels
-        img_height: Original image height in pixels
-        
-    Returns:
-        Tuple of (width, height) in character cells that fit the terminal
-    """
-    try:
-        term_size = shutil.get_terminal_size()
-        term_cols = term_size.columns
-        term_rows = term_size.lines
-    except Exception:
-        # Fallback to a reasonable default if terminal size can't be determined
-        term_cols, term_rows = 80, 24
-    
-    # Leave margin for prompt and output (2 rows for prompt, 2 cols for spacing)
-    max_rows = max(term_rows - 2, 1)
-    max_cols = max(term_cols - 2, 1)
-    
-    # Calculate aspect ratio of the image
-    # Default to 1.0 (square) for edge cases of zero dimensions
-    if img_height > 0 and img_width > 0:
-        img_aspect = img_width / img_height
-    else:
-        # If either dimension is zero, treat as square (1:1)
-        img_aspect = 1.0
-    
-    # Terminal character cells are typically twice as tall as they are wide
-    # So to preserve image aspect ratio, we need to account for this:
-    # If image is W x H pixels, and we want it to look right in terminal,
-    # we need (cols / 2) / rows = W / H
-    # Therefore: cols = 2 * rows * (W / H)
-    # And: rows = cols / (2 * (W / H))
-    
-    # Try fitting by width first
-    # rows = cols / (2 * aspect)
-    rows_if_full_width = max_cols / (2 * img_aspect)
-    
-    if rows_if_full_width <= max_rows:
-        # Image fits when using full width
-        return max_cols, max(1, int(rows_if_full_width))
-    else:
-        # Image is too tall, constrain by height
-        # cols = 2 * rows * aspect
-        cols_if_full_height = 2 * max_rows * img_aspect
-        
-        if cols_if_full_height <= max_cols:
-            # Fits within column constraint
-            return max(1, int(cols_if_full_height)), max_rows
-        else:
-            # Still too wide even at max height, just use max dimensions
-            # This shouldn't normally happen with reasonable images
-            return max_cols, max_rows
-
-
 class FigureManagerICat(FigureManagerBase):
     def show(self):
         with BytesIO() as buf:
@@ -110,16 +51,7 @@ class FigureManagerICat(FigureManagerBase):
             # Check if fit is enabled via environment variable
             fit_enabled = getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
             
-            if fit_enabled:
-                # Get image dimensions
-                buf.seek(0)
-                img = Image.open(buf)
-                img_width, img_height = img.size
-                # Don't close img here - it would close the underlying buffer
-                buf.seek(0)
-                _icat(output=False, input=buf.getvalue(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
-            else:
-                _icat(output=False, input=buf.getvalue())
+            _icat(output=False, input=buf.getvalue(), fit_to_terminal=fit_enabled)
 
 
 class FigureCanvasICat(FigureCanvasAgg):
@@ -195,12 +127,9 @@ class ICatMagics(Magics):
         with BytesIO() as buf:
             img.save(buf, format="PNG")
             
-            if fit_enabled and not (args.width or args.height):
-                # Only apply fit if manual dimensions aren't specified
-                img_width, img_height = img.size
-                _icat(output=False, input=buf.getvalue(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
-            else:
-                _icat(output=False, input=buf.getvalue())
+            # Only apply fit if manual dimensions aren't specified
+            should_fit = fit_enabled and not (args.width or args.height)
+            _icat(output=False, input=buf.getvalue(), fit_to_terminal=should_fit)
 
 
 def icat(img: Image.Image, width: Optional[int] = None, height: Optional[int] = None, fit: bool = False):
@@ -222,12 +151,9 @@ def icat(img: Image.Image, width: Optional[int] = None, height: Optional[int] = 
             img_.thumbnail((width or img.width, height or img.height))
         img_.save(buf, format="PNG")
         
-        if fit_enabled and not (width or height):
-            # Only apply fit if manual dimensions aren't specified
-            img_width, img_height = img_.size
-            _icat(output=False, input=buf.getvalue(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
-        else:
-            _icat(output=False, input=buf.getvalue())
+        # Only apply fit if manual dimensions aren't specified
+        should_fit = fit_enabled and not (width or height)
+        _icat(output=False, input=buf.getvalue(), fit_to_terminal=should_fit)
 
 
 def load_ipython_extension(ipython):

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -67,10 +67,11 @@ def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
     max_cols = max(term_cols - 2, 1)
     
     # Calculate aspect ratio of the image
-    # Default to 1.0 (square) for edge case of zero height
-    if img_height > 0:
+    # Default to 1.0 (square) for edge cases of zero dimensions
+    if img_height > 0 and img_width > 0:
         img_aspect = img_width / img_height
     else:
+        # If either dimension is zero, treat as square (1:1)
         img_aspect = 1.0
     
     # Terminal character cells are typically twice as tall as they are wide

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -48,8 +48,8 @@ class FigureManagerICat(FigureManagerBase):
         with BytesIO() as buf:
             self.canvas.figure.savefig(buf, format="png")
             
-            # Check if fit is enabled via environment variable
-            fit_enabled = getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
+            # Check if fit is enabled via environment variable or session state
+            fit_enabled = _is_fit_enabled()
             
             _icat(output=False, input=buf.getvalue(), fit_to_terminal=fit_enabled)
 
@@ -93,7 +93,7 @@ class ICatMagics(Magics):
         target = (args.target or "").strip()
 
         if target in {"", "on"}:
-            _enable_session(self.shell)
+            _enable_session(self.shell, fit=args.fit)
             return
         if target == "off":
             _disable_session(self.shell)
@@ -116,8 +116,8 @@ class ICatMagics(Magics):
             )
             return
 
-        # Check if fit is requested via flag or environment variable
-        fit_enabled = args.fit or getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
+        # Check if fit is requested via flag, environment variable, or session state
+        fit_enabled = args.fit or _is_fit_enabled()
 
         # resize the image if width or height is specified
         if args.width or args.height:
@@ -143,8 +143,8 @@ def icat(img: Image.Image, width: Optional[int] = None, height: Optional[int] = 
     """
     img_ = img.copy()
     
-    # Check if fit is requested via parameter or environment variable
-    fit_enabled = fit or getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}
+    # Check if fit is requested via parameter, environment variable, or session state
+    fit_enabled = fit or _is_fit_enabled()
     
     with BytesIO() as buf:
         if width or height:
@@ -168,9 +168,32 @@ def _session_state(shell) -> dict:
     return shell.user_ns.setdefault("_icat_state", {})
 
 
-def _enable_session(shell) -> None:
+def _is_fit_enabled() -> bool:
+    """Check if fit is enabled via environment variable or session state."""
+    # Check environment variable first
+    if getenv("IPYTHON_ICAT_FIT", "").strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    
+    # Check session state
+    try:
+        ip = get_ipython()
+        if ip is not None:
+            state = ip.user_ns.get("_icat_state", {})
+            return bool(state.get("fit"))
+    except NameError:
+        # get_ipython not available outside IPython context
+        pass
+    
+    return False
+
+
+def _enable_session(shell, fit: bool = False) -> None:
     state = _session_state(shell)
     if state.get("enabled"):
+        # If already enabled, just update fit setting if requested
+        if fit:
+            state["fit"] = True
+            print("icat: auto-fit enabled for all images")
         return
 
     try:
@@ -178,9 +201,13 @@ def _enable_session(shell) -> None:
     except Exception:
         state["prev_mpl_backend"] = None
 
+    # Store fit setting in session state
+    state["fit"] = fit
+
     try:
         matplotlib.use("module://icat")
-        print("icat: enabled matplotlib backend + PIL auto-render")
+        fit_msg = " (with auto-fit)" if fit else ""
+        print(f"icat: enabled matplotlib backend + PIL auto-render{fit_msg}")
     except Exception as e:
         print(f"icat: failed to enable matplotlib backend: {e}")
 
@@ -222,8 +249,9 @@ def _print_status(shell) -> None:
         current = matplotlib.get_backend()
     except Exception:
         pass
+    fit = bool(state.get("fit"))
     print(
-        f"icat: enabled={enabled}, matplotlib_backend={current!r}, prev_backend={prev!r}"
+        f"icat: enabled={enabled}, fit={fit}, matplotlib_backend={current!r}, prev_backend={prev!r}"
     )
 
 

--- a/icat/__init__.py
+++ b/icat/__init__.py
@@ -25,7 +25,7 @@ def _run(*cmd):
         # Build command with optional fit parameters
         cmd_args = list(args)
         
-        if fit_to_terminal and img_width and img_height:
+        if fit_to_terminal and img_width is not None and img_height is not None:
             # Calculate terminal-fit dimensions
             fit_width, fit_height = _get_fit_dimensions(img_width, img_height)
             # Use --place to specify cell dimensions for kitty
@@ -67,7 +67,11 @@ def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
     max_cols = max(term_cols - 2, 1)
     
     # Calculate aspect ratio of the image
-    img_aspect = img_width / img_height if img_height > 0 else 1.0
+    # Default to 1.0 (square) for edge case of zero height
+    if img_height > 0:
+        img_aspect = img_width / img_height
+    else:
+        img_aspect = 1.0
     
     # Terminal character cells are typically twice as tall as they are wide
     # So to preserve image aspect ratio, we need to account for this:
@@ -77,6 +81,7 @@ def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
     # And: rows = cols / (2 * (W / H))
     
     # Try fitting by width first
+    # rows = cols / (2 * aspect)
     rows_if_full_width = max_cols / (2 * img_aspect)
     
     if rows_if_full_width <= max_rows:
@@ -84,6 +89,7 @@ def _get_fit_dimensions(img_width: int, img_height: int) -> tuple[int, int]:
         return max_cols, max(1, int(rows_if_full_width))
     else:
         # Image is too tall, constrain by height
+        # cols = 2 * rows * aspect
         cols_if_full_height = 2 * max_rows * img_aspect
         
         if cols_if_full_height <= max_cols:
@@ -108,7 +114,7 @@ class FigureManagerICat(FigureManagerBase):
                 buf.seek(0)
                 img = Image.open(buf)
                 img_width, img_height = img.size
-                img.close()  # Close to release buffer
+                # Don't close img here - it would close the underlying buffer
                 buf.seek(0)
                 _icat(output=False, input=buf.getvalue(), fit_to_terminal=True, img_width=img_width, img_height=img_height)
             else:


### PR DESCRIPTION
Adds automatic image fitting to terminal dimensions while preserving aspect ratio with a new kitten argument (https://github.com/kovidgoyal/kitty/commit/a814ab4c2e915da54389db1a0334a3fcd89becd3). Images and matplotlib plots can now scale to available terminal space using the `--fit` flag or `IPYTHON_ICAT_FIT` environment variable.

### CHANGES
* **%icat --fit flag** - Enables auto-fit for individual commands or as a session-wide setting
* **IPYTHON_ICAT_FIT environment variable** - Globally enables auto-fit when set to 1/true/yes/on
* **Dimension precedence** - Manual -W/-H arguments override auto-fit
* **Session-level fit** - Running `%icat --fit` enables auto-fit
* **Updated CLAUDE.md** - Added documentation for --fit functionality

### USAGE
```bash
# Enable icat with auto-fit for the entire session
%icat --fit

# Per-image fitting
%icat image.jpg --fit

# Global via environment variable
export IPYTHON_ICAT_FIT=1
%icat image.jpg  # Automatically fits

# Manual dimensions take precedence
%icat image.jpg --fit -W 300  # Uses 300, ignores fit
```

### IMPLEMENTATION NOTES
Uses kitty's native `--scale-up --fit both` options to properly scale images to fill the terminal while preserving aspect ratio. This leverages the fit features implemented in https://github.com/kovidgoyal/kitty/commit/a814ab4c2e915da54389db1a0334a3fcd89becd3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-fit option to scale images/plots to terminal size via a new --fit flag and explicit API option.
  * Persistent auto-fit control via IPYTHON_ICAT_FIT and auto-enable via IPYTHON_ICAT_AUTO.

* **Documentation**
  * Added usage examples for --fit, status output showing fit state, and instructions to enable auto-fit by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->